### PR TITLE
#162948882 Users should be able to share articles on social media and via email

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "react-scripts": "^2.1.5",
     "react-select": "^2.4.1",
     "react-semantic-toasts": "^0.4.1",
+    "react-share": "^2.4.0",
     "react-test-renderer": "^16.8.1",
     "react-toastify": "^4.5.2",
     "react-ultimate-pagination": "^1.2.0",

--- a/src/assets/css/App.scss
+++ b/src/assets/css/App.scss
@@ -227,6 +227,39 @@ $primary-color: black;
     width: 100%;
     height: 200px;
 }
+
 .comment-container{
   padding-bottom: 120px;
+}
+
+.titleCard{
+  height: 50px;
+}
+
+#social-sharing{
+  position: fixed;
+  left: 5%;
+  top: 50%;
+}
+
+.socialIcon:hover{
+  -webkit-transform: rotateZ(720deg);
+  -moz-transform: rotateZ(720deg);
+  transform: rotateZ(720deg);
+
+}
+
+.share-icons{
+  padding-bottom: 10px;
+}
+
+.socialIcon{
+cursor: pointer;
+-webkit-transition: 0.3s ease-out;
+-moz-transition:  0.3s ease-out;
+transition:  0.3s ease-out;
+}
+
+#social-sharing .email circle{
+  fill: #ef5350;
 }

--- a/src/assets/css/index.scss
+++ b/src/assets/css/index.scss
@@ -82,6 +82,11 @@ a:hover {
   width: 750px;
 }
 
+.body p img {
+  width: 750px;
+  padding: 20px 0;
+  }
+
 .legend {
   background: transparent;
   border: 1px;
@@ -392,4 +397,8 @@ img.ui.avatar.image {
   display: flex;
   flex-direction: row;
   align-items: space-around;
+}
+
+.no-rating {
+  padding-right: 180px;
 }

--- a/src/components/containers/articles/OneArticle.js
+++ b/src/components/containers/articles/OneArticle.js
@@ -18,6 +18,7 @@ import getOneArticle from "../../../actions/getOneArticleAction";
 import ArticleRating from "../rating/Rating";
 import CommentsContainer from "../commentsContainer";
 import ArticleLiking from "../likes/ArticleLiking";
+import SocialShare from "../sharing";
 
 export class GetOneArticle extends Component {
   constructor() {
@@ -111,6 +112,7 @@ export class GetOneArticle extends Component {
                   <br />
                   <br />
                 </div>
+                <SocialShare slug={article.slug} title={article.title} author={article.author.username} />
               </div>
               <div className="intro-image">
                 {!article.image_path ? (
@@ -142,7 +144,7 @@ export class GetOneArticle extends Component {
                     {loggedOut ? (
                       <div />
                     ) : localStorage.getItem("username") === article.author.username ? (
-                      <div />
+                      <div className="no-rating" />
                     ) : (
                       <span className="rating-bar">
                         <ArticleRating

--- a/src/components/containers/articles/UserArticles.js
+++ b/src/components/containers/articles/UserArticles.js
@@ -37,7 +37,7 @@ export class UserArticles extends Component {
                   {moment(article.created_at, "YYYYMMDD").fromNow()}
                 </span>
               </Card.Meta>
-              <Card.Description>
+              <Card.Description className="titleCard">
                 <Link
                   to={{
                     pathname: `/${article.slug}`,

--- a/src/components/containers/sharing/ShareIcons.js
+++ b/src/components/containers/sharing/ShareIcons.js
@@ -1,0 +1,55 @@
+import React, { Component } from "react";
+import {
+  FacebookShareButton,
+  EmailShareButton,
+  TwitterShareButton,
+  FacebookIcon,
+  TwitterIcon,
+  EmailIcon
+} from "react-share";
+
+class ShareIcons extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+    };
+  }
+
+  render() {
+    const template = "Highlights from Author's Haven";
+    const { shareURL, title, author } = this.props;
+    const shareTitle = `Take a look at this:  ${title}`;
+    const articleAuthor = `${author.charAt(0).toUpperCase() + author.substr(1).toLowerCase()}`;
+    const emailBody = `Hello\nTake a look at this article by ${articleAuthor} \n ${shareURL}`;
+
+    return (
+      <div id="social-sharing">
+        <TwitterShareButton
+          url={shareURL}
+          title={shareTitle}
+          className="share-icons"
+        >
+          <TwitterIcon className="socialIcon" size={40} round />
+        </TwitterShareButton>
+
+        <FacebookShareButton
+          url={shareURL}
+          quote={shareTitle}
+          className="share-icons"
+        >
+          <FacebookIcon className="socialIcon" size={40} round />
+        </FacebookShareButton>
+
+        <EmailShareButton
+          body={emailBody}
+          subject={template}
+          className="share-icons"
+        >
+          <EmailIcon className="socialIcon email " size={40} round />
+        </EmailShareButton>
+      </div>
+    );
+  }
+}
+
+export default ShareIcons;

--- a/src/components/containers/sharing/__test__/ShareIcon.test.js
+++ b/src/components/containers/sharing/__test__/ShareIcon.test.js
@@ -1,0 +1,20 @@
+import React from "react";
+import { shallow } from "enzyme";
+import ShareIcons from "../ShareIcons";
+
+describe("EditArticle", () => {
+  let props;
+  let wrapper;
+  beforeEach(() => {
+    props = {
+      slug: "book",
+      title: "title",
+      author: "bolt"
+    };
+    wrapper = shallow(<ShareIcons {...props} />);
+  });
+
+  it("should mach snapshots", () => {
+    expect(wrapper).toMatchSnapshot();
+  });
+});

--- a/src/components/containers/sharing/index.js
+++ b/src/components/containers/sharing/index.js
@@ -1,0 +1,13 @@
+/* eslint-disable react/prefer-stateless-function */
+import React, { Component } from "react";
+import ShareIcons from "./ShareIcons";
+
+class SocialShare extends Component {
+  render() {
+    const { title, slug, author } = this.props;
+    const shareURL = `https://ah-alpha-frontend-staging.herokuapp.com/${slug}`;
+    return <ShareIcons shareURL={shareURL} title={title} author={author} />;
+  }
+}
+
+export default SocialShare;


### PR DESCRIPTION
#### What does this PR do?
*  Implements sharing of articles on social media and via email

#### Description of Task to be completed?

- create share article UI with facebook, twitter, and email
- share articles through the UI

#### How should this be manually tested?
* Clone ah-alpha repo `git clone https://github.com/andela/ah-alpha.git`
* Checkout to the branch `ft-share-articles-162948882`
* Install the required dependencies using `npm install`
* Run the local development server using `npm start`
* Click on one article to view the social icons
* Click one of the social icons to share the viewed article

#### Screenshot
![image](https://user-images.githubusercontent.com/43441107/53555017-2116a500-3b52-11e9-8ff8-ef691f632f83.png)



#### What are the relevant pivotal tracker stories?
[#162948882](https://www.pivotaltracker.com/story/show/162948882